### PR TITLE
Revert "chore(deps): update emqx/emqx docker tag to v5.9.0"

### DIFF
--- a/apps/connectivity/emqx/values.yaml
+++ b/apps/connectivity/emqx/values.yaml
@@ -5,4 +5,4 @@ emqx-operator:
 cluster:
   image:
     repository: emqx/emqx
-    tag: 5.9.0
+    tag: 5.8.6


### PR DESCRIPTION
Reverts broersma-forslund/homelab#1156

See https://github.com/emqx/emqx/issues/15226