### PR TITLE
rook-ceph-cluster: fix connection settings

### DIFF
--- a/apps/storage/rook-ceph-cluster/rook-cluster-values.yaml
+++ b/apps/storage/rook-ceph-cluster/rook-cluster-values.yaml
@@ -20,11 +20,12 @@ rook-ceph-cluster:
       image: quay.io/ceph/ceph:v19.2.2
 
     network:
+      connections:
+        encryption:
+          enabled: false
+        compression:
+          enabled: false
       provider: host
-      encryption:
-        enabled: false
-      compression:
-        enabled: false
       addressRanges:
         public: ['10.0.102.0/24']
         cluster: ['10.0.104.0/24']


### PR DESCRIPTION
While these are already false by default, it does not match the correct format: https://github.com/rook/rook/blob/80563e28b685cc54fc102a59fd3012a36e537841/deploy/charts/rook-ceph-cluster/values.yaml#L175 