### PR TITLE
dawarich: recreate photon PVC to 20Gi instead of 500Gi

### DIFF
--- a/apps/home/dawarich/values.yaml
+++ b/apps/home/dawarich/values.yaml
@@ -28,7 +28,7 @@ dawarich:
       updateInterval: '168h'
       logLevel: DEBUG
     persistence:
-      size: 500Gi
+      size: 20Gi
 
 
   redis:


### PR DESCRIPTION
Since you use the countrycode NL the Photon only needs about 10Gi when downloading the geodata. 500Gi is a bit much, since it would never need it. This however requires you to recreate the Statefulset