### PR TITLE
[tuppr] Update Talos image repository for renovate

### DIFF
--- a/apps/cluster/talos-updater/values.yaml
+++ b/apps/cluster/talos-updater/values.yaml
@@ -9,7 +9,7 @@ tuppr:
 
 talos:
     image:
-      repository: ghcr.io/siderolabs/installer
+      repository: ghcr.io/siderolabs/talos
       tag: v1.13.9
 kubernetes:
   image:


### PR DESCRIPTION
Talos 1.14 no longer publishes ghcr.io/siderolabs/installer, so Renovate cannot discover the new release.

Point the Tuppr Talos image reference at ghcr.io/siderolabs/talos, matching Tuppr's documented Renovate dependency and allowing future Talos releases to be detected.